### PR TITLE
Let init script template find redis-server in CentOS 7

### DIFF
--- a/templates/init-RedHat.erb
+++ b/templates/init-RedHat.erb
@@ -9,7 +9,7 @@
 . /etc/rc.d/init.d/functions
 
 name="redis-server"
-exec="/usr/sbin/$name"
+exec=$(/usr/bin/which ${name})
 pidfile="<%= @pidfile %>"
 REDIS_CONFIG="<%= @config_file %>"
 


### PR DESCRIPTION
The path for redis-server changed in CentOS 7 from `/usr/sbin/redis-server` to `/bin/redis-server`. The init script template was hard coded to look in `/usr/sbin/`. I've updated the template to use `which` to find the path for `redis-server`. We can't use a symlink here or just use the executable name; `$exec` needs to contain the full path to the executable due to the `test -x` we do on [line 23](https://github.com/newrelic/puppet-redis/blob/master/templates/init-RedHat.erb#L23).
